### PR TITLE
Add File-based Configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,9 @@ dependencies {
     nativeRelease wpi.java.vendor.jniRelease(wpi.platforms.desktop)
     simulationRelease wpi.sim.enableRelease()
 
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation(platform('org.junit:junit-bom:5.11.4'))
+	testImplementation('org.junit.jupiter:junit-jupiter')
+	testRuntimeOnly('org.junit.platform:junit-platform-launcher')
 }
 
 test {

--- a/src/main/java/frc/robot/Config.java
+++ b/src/main/java/frc/robot/Config.java
@@ -22,7 +22,15 @@ public class Config {
         this("./src/main/resources/robot.properties");
     }
 
-    protected RobotConfig readGeneratedConfig() {
+    public Integer readIntegerProperty(String property) {
+        var rawProperty = fileConfig.getProperty(property);
+        if (rawProperty == null) {
+            throw new RuntimeException(property + " was not found.");
+        }
+        return Integer.parseInt(rawProperty);
+    }
+
+    protected static RobotConfig readGeneratedConfig() {
         try {
             return RobotConfig.fromGUISettings();
         } catch (IOException | ParseException e) {

--- a/src/main/java/frc/robot/Config.java
+++ b/src/main/java/frc/robot/Config.java
@@ -1,0 +1,45 @@
+package frc.robot;
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Properties;
+
+import org.json.simple.parser.ParseException;
+
+import com.pathplanner.lib.config.RobotConfig;
+
+public class Config {
+    public final RobotConfig generatedConfig;
+    public final Properties fileConfig;
+
+    public Config(String fileLocation) {
+        generatedConfig = readGeneratedConfig();
+        fileConfig = readFileConfig(fileLocation);
+    }
+
+    public Config() {
+        this("./src/main/resources/robot.properties");
+    }
+
+    protected RobotConfig readGeneratedConfig() {
+        try {
+            return RobotConfig.fromGUISettings();
+        } catch (IOException | ParseException e) {
+            throw new Error("Unable to load Robot Config: %s".formatted(e.getMessage()));
+        }
+    }
+
+    public static Properties readFileConfig(String path) {
+        var properties = new Properties();
+        try {
+            var reader = new FileReader(path);
+            properties.load(reader);
+            return properties;
+        } catch (FileNotFoundException e) {
+            throw new Error("Unable to find property file: %s".formatted(e.getMessage()));
+        } catch (IOException e) {
+            throw new Error("IOException when reading property file: %s".formatted(e.getMessage()));
+        }
+    } 
+}

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -6,12 +6,7 @@ package frc.robot;
 
 import static edu.wpi.first.units.Units.*;
 
-import java.io.IOException;
-
-import org.json.simple.parser.ParseException;
-
 import com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType;
-import com.pathplanner.lib.config.RobotConfig;
 import com.ctre.phoenix6.swerve.SwerveRequest;
 
 import edu.wpi.first.math.geometry.Rotation2d;
@@ -36,7 +31,7 @@ public class RobotContainer {
 
     private final Telemetry logger = new Telemetry(MaxSpeed);
 
-    private final RobotConfig config = readConfig();
+    private final Config config = new Config();
 
     private final CommandXboxController joystick = new CommandXboxController(0);
 
@@ -46,15 +41,6 @@ public class RobotContainer {
 
     public RobotContainer() {
         configureBindings();
-    }
-
-    private static RobotConfig readConfig() {
-        try {
-            return RobotConfig.fromGUISettings();
-        } catch (IOException | ParseException e) {
-            e.printStackTrace();
-            throw new Error("Unable to load Robot Config: %s".formatted(e.getMessage()));
-        }
     }
 
     private void configureBindings() {

--- a/src/main/java/frc/robot/subsystems/autonomous/AutonomousControllerImpl.java
+++ b/src/main/java/frc/robot/subsystems/autonomous/AutonomousControllerImpl.java
@@ -3,9 +3,9 @@ package frc.robot.subsystems.autonomous;
 import java.util.function.BooleanSupplier;
 
 import com.pathplanner.lib.auto.AutoBuilder;
-import com.pathplanner.lib.config.RobotConfig;
 
 import edu.wpi.first.wpilibj2.command.Commands;
+import frc.robot.Config;
 
 /**
  * Initial implementation of the Autonomous mode behavior
@@ -14,7 +14,7 @@ public class AutonomousControllerImpl implements AutonomousController {
 
     private static AutonomousControllerImpl controller;
 
-    private AutonomousControllerImpl(RobotConfig config, PathPlannableSubsystem driveSystem) {
+    private AutonomousControllerImpl(Config config, PathPlannableSubsystem driveSystem) {
         // Boolean supplier that controls when the path will be mirrored for the red
         // alliance
         // This will flip the path being followed to the red side of the field.
@@ -27,12 +27,12 @@ public class AutonomousControllerImpl implements AutonomousController {
                 driveSystem::getRobotRelativeChassisSpeeds,
                 driveSystem::driveRobotRelative,
                 driveSystem.getPathFollowingController(),
-                config,
+                config.generatedConfig,
                 requiresFlip,
                 driveSystem);
     }
 
-    public static synchronized AutonomousControllerImpl initialize(RobotConfig config, PathPlannableSubsystem driveSystem) {
+    public static synchronized AutonomousControllerImpl initialize(Config config, PathPlannableSubsystem driveSystem) {
         controller = new AutonomousControllerImpl(config, driveSystem);
         return controller;
     }

--- a/src/test/java/frc/robot/ConfigTests.java
+++ b/src/test/java/frc/robot/ConfigTests.java
@@ -1,6 +1,6 @@
-import org.junit.jupiter.api.Test;
+package frc.robot;
 
-import frc.robot.Config;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/frc/robot/ConfigTests.java
+++ b/src/test/java/frc/robot/ConfigTests.java
@@ -1,0 +1,30 @@
+import org.junit.jupiter.api.Test;
+
+import frc.robot.Config;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ConfigTests {
+ 
+    private static final String testPath = "./src/test/resources/test.properties";
+
+    @Test
+    void canLoadFromRoot() {
+        Config.readFileConfig(testPath);
+    }
+
+    @Test
+    void throwsErrorWhenNotFound() {
+        assertThrows(Error.class, () -> {
+            Config.readFileConfig("./src/test/resources/not-found.properties");
+        });
+    }
+
+    @Test
+    void readProperty() {
+        var cfg = Config.readFileConfig(testPath);
+        var testAmps = cfg.getProperty("example.motor.amps");
+        assertEquals("40", testAmps);
+    }
+}

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,0 +1,1 @@
+example.motor.amps=40


### PR DESCRIPTION
## Summary
Adds a `Config` class to wrap the generated `RobotConfig` and configuration read in from a file (`robot.properties')