### PR TITLE
Update Swerve Drive to use CTRE's kinematics and odometry

### DIFF
--- a/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -292,17 +292,11 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Pa
         return this.getState().ModuleStates;
     }
 
-    @Override
     public Pose2d getPose() {
         return this.getState().Pose;
     }
 
-    // The SwerveDriveTrain class already has an identical resetPose() function that
-    // is being overriden by the one we wrote, so I have removed ours.
-    /* @Override
-    public void resetPose(Pose2d pose) {
-        this.resetPose(pose);
-    } */
+    // The SwerveDriveTrain class already has a resetPose() function.
 
     @Override
     public ChassisSpeeds getRobotRelativeChassisSpeeds() {

--- a/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -44,8 +44,6 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Pa
     private Notifier m_simNotifier = null;
     private double m_lastSimTime;
 
-    private Double discretizationDelta;
-
     /* Blue alliance sees forward as 0 degrees (toward red alliance wall) */
     private static final Rotation2d kBlueAlliancePerspectiveRotation = Rotation2d.kZero;
     /* Red alliance sees forward as 180 degrees (toward blue alliance wall) */

--- a/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -44,6 +44,8 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Pa
     private Notifier m_simNotifier = null;
     private double m_lastSimTime;
 
+    private Double discretizationDelta;
+
     /* Blue alliance sees forward as 0 degrees (toward red alliance wall) */
     private static final Rotation2d kBlueAlliancePerspectiveRotation = Rotation2d.kZero;
     /* Red alliance sees forward as 180 degrees (toward blue alliance wall) */
@@ -204,7 +206,6 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Pa
 
     private void initialize(Config config) {
         discretizationDelta = config.readDoubleProperty("drivetrain.chassis.speed.discretization.delta.seconds");
-        // The swerve drive kinematics class supplies kinematics for us.
 
         if (Utils.isSimulation()) {
             startSimThread();
@@ -319,7 +320,7 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Pa
     @Override
     public void driveRobotRelative(ChassisSpeeds robotRelativeSpeeds, DriveFeedforwards driveFeedforwards) {
         System.out.println("driveRobotRelative::robotRelativeSpeeds:: " + robotRelativeSpeeds.toString());
-        ChassisSpeeds targetSpeeds = ChassisSpeeds.discretize(robotRelativeSpeeds, this.getOdometryFrequency());
+        ChassisSpeeds targetSpeeds = ChassisSpeeds.discretize(robotRelativeSpeeds, this.discretizationDelta);
 
         logModuleState("Before", getModuleStates());
         this.setControl(new SwerveRequest.ApplyRobotSpeeds()


### PR DESCRIPTION
I have edited the pathplanner functions to fully use the SwerveDrivetrain (which CommandSwerveDrivetrain inherits) class for the pathplanner functions, and I have deleted the odometry and kinematics variables, since we don't need them. Also, the SwerveDrivetrain class already implements a resetPose function, so I removed the function from our code (It still satisfies the interface).